### PR TITLE
Fix hammerjs missing dependency in karma tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,6 +10,8 @@ module.exports = function(config) {
       watched: false
     }, {
       pattern: './node_modules/@angular/material/prebuilt-themes/indigo-pink.css'
+    }, {
+      pattern: './node_modules/hammerjs/hammer.js'
     }],
     plugins: [
       require('karma-jasmine'),


### PR DESCRIPTION
This patch fixes `Error: Hammer.js is not loaded, can not bind swiperight event` when running unit tests.

How to test:
* Run `npm run test`
--> All unit tests must pass without any error