### PR TITLE
Fix preview pane for large devices

### DIFF
--- a/src/app/product-add/product-preview/product-preview.component.scss
+++ b/src/app/product-add/product-preview/product-preview.component.scss
@@ -1,17 +1,19 @@
 .item-card {
-
-  @media (max-width: 600px) {
+  // Small devices (landscape phones, 576px and up)
+  @media (min-width: 576px) {
     margin-top: 20px;
-  }
-  /* medium*/
-  @media (min-width: 601px) and (max-width: 992px) {
+  } // Medium devices (tablets, 768px and up)
+  @media (min-width: 768px) {
     margin-top: 30px;
-  }
-  /* large */
-  @media (min-width: 993px) {
+  } // Large devices (desktops, 992px and up)
+  @media (min-width: 992px) {
+    margin-top: 20px;
+  } // Extra large devices (large desktops, 1200px and up)
+  @media (min-width: 1200px) {
     position: fixed;
-    top: 25%;
-    left: 63%;
+    top: %25;
+    left: auto;
+    right: auto;
   }
 
   .item-card-header {


### PR DESCRIPTION
Prerequisite
* Functional test must be done with a large screen (933px + wide)

How to test:
* Click on "add a new ugly pullover"
    - Preview pane shouldn't have a fixed position
    - Preview pane should not be cut on the right

Ensure that other devices resolutions are not broken